### PR TITLE
Use stable version of click (8.0.1 instead of 8.0.0a1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     },
     install_requires=[
         "colorama==0.4.4",
-        "click==8.0.0a1",
+        "click==8.0.1",
         "emoji==1.2.0",
         "gitpython==3.1.12",
         "idna==2.10",


### PR DESCRIPTION
### What?

- Use stable version of click (8.0.1 instead of 8.0.0a1)

### Why?

- Could not be well managed with pip, considering the version as a pre-release (that is skipped by default with pipenv for example)